### PR TITLE
Fix element query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ window.livewire.directive('sortable', (el, directive, component) => {
         setTimeout(() => {
             let items = []
 
-            document.querySelectorAll('[wire\\:sortable\\.item]').forEach((el, index) => {
+            el.querySelectorAll('[wire\\:sortable\\.item]').forEach((el, index) => {
                 items.push({ order: index + 1, value: el.getAttribute('wire:sortable.item')})
             })
 


### PR DESCRIPTION
I was attempting to use this in two different spots on the same page and it was sending all of the elements from _all_ sortable lists.

This solves that problem.