### PR TITLE
New SOURCE Group and TARGET Group attributes for quick identification of Dragged Item, and Filtering (wire:sortable-group.filter-updated)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,20 +21,45 @@ window.livewire.directive('sortable-group', (el, directive, component) => {
 
     const sortable = el.livewire_sortable = new Sortable([], options);
 
-    sortable.on('sortable:stop', () => {
+    sortable.on('sortable:stop', (el) => {
+
+        // New Source Group, Target Group, and Item attributes
+        let sourceItem = el.dragEvent.data.source.getAttribute('wire:sortable-group.item')
+        let sourceGroup = el.data.oldContainer.getAttribute('wire:sortable-group.item-group')
+        let targetGroup = el.data.newContainer.getAttribute('wire:sortable-group.item-group')
+
+        // If wire:sortable-group.filter-updated exists then filter
+        let isFilterUpdatedGroups = e.hasAttribute('wire:sortable-group.filter-updated') ? true : false
+
         setTimeout(() => {
             let groups = []
 
             el.querySelectorAll('[wire\\:sortable-group\\.item-group]').forEach((el, index) => {
                 let items = []
                 el.querySelectorAll('[wire\\:sortable-group\\.item]').forEach((el, index) => {
-                    items.push({ order: index + 1, value: el.getAttribute('wire:sortable-group.item')})
+                    items.push({
+            order: index + 1,
+            value: el.getAttribute('wire:sortable-group.item'),
+            item: sourceItem == e.getAttribute("wire:sortable-group.item") ? true : false,
+            })
                 })
+
+                let isSource = sourceGroup == e.getAttribute("wire:sortable-group.item-group") ? true : false
+                let isTarget = targetGroup == e.getAttribute("wire:sortable-group.item-group") ? true : false
+
+                if (isFilterUpdatedGroups) {
+                  // skip if group not included in drag
+                  if (!isSource && !isTarget) {
+                      return
+                  }
+                }
 
                 groups.push({
                     order: index + 1,
                     value: el.getAttribute('wire:sortable-group.item-group'),
                     items: items,
+                    source: isSource,
+                    target: isTarget,					
                 })
             })
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,10 +38,10 @@ window.livewire.directive('sortable-group', (el, directive, component) => {
                 let items = []
                 el.querySelectorAll('[wire\\:sortable-group\\.item]').forEach((el, index) => {
                     items.push({
-            order: index + 1,
-            value: el.getAttribute('wire:sortable-group.item'),
-            item: sourceItem == e.getAttribute("wire:sortable-group.item") ? true : false,
-            })
+                    order: index + 1,
+                    value: el.getAttribute('wire:sortable-group.item'),
+                    item: sourceItem == e.getAttribute("wire:sortable-group.item") ? true : false,
+                    })
                 })
 
                 let isSource = sourceGroup == e.getAttribute("wire:sortable-group.item-group") ? true : false


### PR DESCRIPTION
To make it faster to identify the Item dragged and its Source and Target groups, I've modified the sortable:stop event

This is a non-breaking change -- it only adds additional attributes

NOTE: If Group has Source and Target attributes as True, it means the Item was dragged within that group, rather than to another group

Adding wire:sortable-group.filter-updated attribute will filter only groups updated by drag

https://user-images.githubusercontent.com/20057194/206751855-2687fb1b-9a7c-4545-b81a-e6be7b9df2ca.png