### PR TITLE
Require pointer to have moved before drag starts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,10 @@ window.Livewire?.directive('sortable-group', ({el, directive, component}) => {
     // Only fire the rest of this handler on the "root" directive.
     if (directive.modifiers.length > 0) return
 
-    let options = { draggable: '[wire\\:sortable-group\\.item]' }
+    let options = {
+        draggable: '[wire\\:sortable-group\\.item]',
+        distance: 10,
+    }
 
     if (el.querySelector('[wire\\:sortable-group\\.handle]')) {
         options.handle ='[wire\\:sortable-group\\.handle]'


### PR DESCRIPTION
## Issue
Our application has a sortable item that could also be clicked (think cards on a Trello board).

When using Macbook trackpads with "tap to click" disabled, we could never click to open the item. It would always attempt to sort it instead.

## Solution
Require the mouse to be moved a certain distance before the drag behaviour starts.

This was done by adding a "distance" option.

I figure this small distance should be imperceptible for most current users of the library, while fixing this strange behaviour on trackpads.

## Note
I looked at https://github.com/livewire/sortable/pull/21. If it were accepted, I could have added the option in my app without changing the options for everyone. There was no other way I could have change the options in the underlying package otherwise.